### PR TITLE
Rackup takes port with -p not -P parameter

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rackup -P $PORT
+web: bundle exec rackup -p$PORT


### PR DESCRIPTION
* app refused to start on Heroku as the wrong parameter (-P instead of -p) was used to pass the port info

@benbalter: ☝️ 