### PR TITLE
Make issue shadower work with latest Ruby and latest GitHub events

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -27,12 +27,14 @@ class IssueShadower < Sinatra::Base
   end
 
   def issue
-    client.issue repo, payload["issue"]["number"]
+    # client.issue repo, payload["issue"]["number"]
+    payload["issue"]
   end
 
   post "/payload" do
     halt 409 unless signature_valid?
     halt 200 unless issue && payload["action"] == "opened"
-    client.create_issue repo, issue.title, "Shaddow issue for #{issue.html_url}\n---\n" + issue.body
+    client.create_issue repo, issue["title"], "Shaddow issue for #{issue['html_url']}\n---\n" + issue["body"]
+    halt 201
   end
 end

--- a/server.rb
+++ b/server.rb
@@ -23,7 +23,7 @@ class IssueShadower < Sinatra::Base
   end
 
   def repo
-    payload["repository"]["fullname"]
+    payload["repository"]["full_name"]
   end
 
   def issue

--- a/server.rb
+++ b/server.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require 'octokit'
+require 'json'
 
 class IssueShadower < Sinatra::Base
   def client


### PR DESCRIPTION
* require JSON package as newer versions of Ruby won't allow to use that package without explicit depency
* use `full_name`instead of `fullname` in updated event payload
* instead of reaching out to GitHub Enterprise whether an issue with the same id already exists (very unlikely), use the webhook's payload from GitHub.com to create the GitHub Enterprise issue
* in case of a successful issue creation, return 201 instead of bailing out with a type error

@benbalter ☝️ 